### PR TITLE
fix

### DIFF
--- a/lib/Paymentwall/Pingback.php
+++ b/lib/Paymentwall/Pingback.php
@@ -225,7 +225,7 @@ class Paymentwall_Pingback extends Paymentwall_Base
 	 */
 	public function getProductPeriodType()
 	{
-		return $this->getParameter('stype');
+		return $this->getParameter('speriod');
 	}
 
 	/**


### PR DESCRIPTION
There is no stype in neither documentation nor code, the correct parameter is speriod.
