### PR TITLE
Fix type 0 items

### DIFF
--- a/lib/Paymentwall/Pingback.php
+++ b/lib/Paymentwall/Pingback.php
@@ -171,17 +171,7 @@ class Paymentwall_Pingback extends Paymentwall_Base
 	 */
 	public function getType()
 	{
-		$pingbackTypes = array(
-			self::PINGBACK_TYPE_REGULAR,
-			self::PINGBACK_TYPE_GOODWILL,
-			self::PINGBACK_TYPE_NEGATIVE
-		);
-
-		if (!empty($this->parameters['type'])) {
-			if (in_array($this->parameters['type'], $pingbackTypes)) {
-				return intval($this->parameters['type']);
-			}
-		}
+		return $this->getParameter('type');
 	}
 
 	/**
@@ -290,7 +280,7 @@ class Paymentwall_Pingback extends Paymentwall_Base
 	 */
 	public function isDeliverable()
 	{
-		return ($this->getType() === self::PINGBACK_TYPE_REGULAR || $this->getType() === self::PINGBACK_TYPE_GOODWILL);
+		return ($this->getType() == self::PINGBACK_TYPE_REGULAR || $this->getType() == self::PINGBACK_TYPE_GOODWILL);
 	}
 
 	/**


### PR DESCRIPTION
Since paymentwall only sends 3 types of items (0, 1, 2), and only ip's of paymentwall can send queries (whitelist) there's no need checking if the type is inside that array.
0 is considered empty by PHP (at least my build) so this solution should work for everyone.
