### PR TITLE
Let the developer handle the internal error.

### DIFF
--- a/lib/Paymentwall/Pro/Error.php
+++ b/lib/Paymentwall/Pro/Error.php
@@ -57,7 +57,7 @@ class Paymentwall_Pro_Error
 				'message' => 'Sorry, internal error occured'
 			)
 		);
-		die(json_encode($result));
+		return json_encode($result);
 	}
 
 	public static function getPublicData($properties) {


### PR DESCRIPTION
On Internal error happens, for currently the SDK just echo the JSON error string and terminate the script. We should let the developer who use the SDK handles that  error.
