### PR TITLE
getResponseLogInformation in ApiObject needs to be public

### DIFF
--- a/lib/Paymentwall/ApiObject.php
+++ b/lib/Paymentwall/ApiObject.php
@@ -108,7 +108,7 @@ abstract class Paymentwall_ApiObject extends Paymentwall_Instance
 		return $this;
 	}
 
-	protected function getResponseLogInformation()
+	public function getResponseLogInformation()
 	{
 		return $this->_responseLogInformation;
 	}


### PR DESCRIPTION
getResponseLogInformation in ApiObject needs to be public to match HttpAction. Also it needs to be accessible from omnipay.