### PR TITLE
Convert parameters array to string before passing to CURL

### DIFF
--- a/lib/Paymentwall/HttpAction.php
+++ b/lib/Paymentwall/HttpAction.php
@@ -83,7 +83,7 @@ class Paymentwall_HttpAction extends Paymentwall_Instance
 		}
 
 		if (!empty($params)) {
-			curl_setopt($curl, CURLOPT_POSTFIELDS, $params);
+			curl_setopt($curl, CURLOPT_POSTFIELDS, http_build_query($params));
 		}
 
         // CURL_SSLVERSION_TLSv1_2 is defined in libcurl version 7.34 or later

--- a/lib/Paymentwall/HttpAction.php
+++ b/lib/Paymentwall/HttpAction.php
@@ -86,12 +86,12 @@ class Paymentwall_HttpAction extends Paymentwall_Instance
 			curl_setopt($curl, CURLOPT_POSTFIELDS, http_build_query($params));
 		}
 
-        // CURL_SSLVERSION_TLSv1_2 is defined in libcurl version 7.34 or later
-        // but unless PHP has been compiled with the correct libcurl headers it
-        // won't be defined in your PHP instance.  PHP > 5.5.19 or > 5.6.3
-        if (! defined('CURL_SSLVERSION_TLSv1_2')) {
-            define('CURL_SSLVERSION_TLSv1_2', 6);
-        }
+		// CURL_SSLVERSION_TLSv1_2 is defined in libcurl version 7.34 or later
+		// but unless PHP has been compiled with the correct libcurl headers it
+		// won't be defined in your PHP instance.  PHP > 5.5.19 or > 5.6.3
+		if (! defined('CURL_SSLVERSION_TLSv1_2')) {
+			define('CURL_SSLVERSION_TLSv1_2', 6);
+		}
 
 		curl_setopt($curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_2);
 		curl_setopt($curl, CURLOPT_CUSTOMREQUEST, $httpVerb);


### PR DESCRIPTION
# Situation
If the parameters array is a multi-dimensional array,  PHP will throw the notice message "Array to string conversion..."

# Solution

Convert parameters array to string before passing to `curl_setopt` function, using `http_build_query` method