### PR TITLE
Changed [] to array() for extra compatibillity

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2010-2015 Paymentwall, Inc.
+Copyright (c) 2010-2018 Paymentwall, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/lib/Paymentwall/Mobiamo.php
+++ b/lib/Paymentwall/Mobiamo.php
@@ -8,11 +8,11 @@ class Paymentwall_Mobiamo extends Paymentwall_ApiObject {
 	}
 	
 	public function getToken($params){
-	    $defaultParams = [
+	    $defaultParams = array(
 	    	'key' => $this->getConfig()->getPublicKey(),
 		    'ts' => time(),
 		    'sign_version' => Paymentwall_Signature_Abstract::VERSION_TWO
-	    ];
+	    );
 	    $params = array_merge($defaultParams, $params);
 	    $params['sign'] = $this->calculateSignature($params);
 	    $this->doApiAction('token', 'post', $params);
@@ -87,7 +87,7 @@ class Paymentwall_Mobiamo extends Paymentwall_ApiObject {
 		}
 	}
 
-	protected function doApiAction($action = '', $method = 'post', $params = [])
+	protected function doApiAction($action = '', $method = 'post', $params = array())
 	{
 		$actionUrl = $this->getApiUrl() . '/' . $action;
 		$httpAction = new Paymentwall_HttpAction($this, $params, [$this->getApiBaseHeader()]);


### PR DESCRIPTION
Using [] gives error when php is under 5.4
changing to array gives wider compatible range
Also changed LICENSE cause now it's 2018 xD