### PR TITLE
Update Product.php

### DIFF
--- a/lib/Paymentwall/Product.php
+++ b/lib/Paymentwall/Product.php
@@ -1,6 +1,6 @@
 <?php
 
-class Paymentwall_Product
+class Paymentwall_Product extends stdClass
 {
 	const TYPE_SUBSCRIPTION = 'subscription';
 	const TYPE_FIXED = 'fixed';


### PR DESCRIPTION
To resolve bug in PHP 8.2;

Creation of dynamic property Paymentwall_Product::$foo is deprecated 